### PR TITLE
Fix #1 Add options to mark the build as failed

### DIFF
--- a/package-drone/pom.xml
+++ b/package-drone/pom.xml
@@ -38,6 +38,11 @@
 			<organizationUrl>http://ibh-systems.com</organizationUrl>
 			<url>http://dentrassi.de</url>
 		</developer>
+		<developer>
+			<id>nfalco79</id>
+			<name>Nikolas Falco</name>
+			<email>nfalco79@hotmail.com</email>
+		</developer>
 	</developers>
 
 	<scm>

--- a/package-drone/src/main/resources/de/dentrassi/pm/jenkins/DroneRecorder/config.jelly
+++ b/package-drone/src/main/resources/de/dentrassi/pm/jenkins/DroneRecorder/config.jelly
@@ -38,6 +38,14 @@
 		<f:entry field="stripPath" >
 			<f:checkbox title="${%stripPath}" default="true"/>
 		</f:entry>
+
+		<f:entry field="allowEmptyArchive" >
+			<f:checkbox title="${%allowEmptyArchive}" default="false"/>
+		</f:entry>
+
+		<f:entry field="failsAsUpload" >
+			<f:checkbox title="${%failsAsUpload}" default="false"/>
+		</f:entry>
 	
 	</f:advanced>
         

--- a/package-drone/src/main/resources/de/dentrassi/pm/jenkins/DroneRecorder/config.properties
+++ b/package-drone/src/main/resources/de/dentrassi/pm/jenkins/DroneRecorder/config.properties
@@ -1,2 +1,6 @@
 defaultExcludes=Default excludes
 stripPath=Strip path
+# Do not fail build if archiving returns nothing
+allowEmptyArchive=Do not fail build if archiving returns nothing
+# Mark the build as failed if the upload fails
+failsAsUpload=Fail the build if upload fails


### PR DESCRIPTION
Add two options to mark the build as failed:
- option to mark the build as failed if there are no artifacts to upload (as the jenkins embedded plugin), that mean something was wrong in the job main steps.
- option to mark the build as failed if something goes wrong in the upload of one artifact. For example deploy key wrong (401 not authorised).
