### PR TITLE
0.3.x pipeline

### DIFF
--- a/package-drone/pom.xml
+++ b/package-drone/pom.xml
@@ -7,7 +7,7 @@
 		<artifactId>plugin</artifactId>
 		<!-- Baseline Jenkins version you use to build and test the plugin. Users 
 			must have this version or newer to run. -->
-		<version>1.580.1</version>
+		<version>2.4</version>
 		<relativePath />
 	</parent>
 
@@ -49,6 +49,11 @@
 			<id>nfalco79</id>
 			<name>Nikolas Falco</name>
 			<email>nfalco79@hotmail.com</email>
+		</developer>
+		<developer>
+			<id>t794104</id>
+			<name>Jurgen Brand</name>
+			<email>jdj.brand@gmail.com</email>
 		</developer>
 	</developers>
 

--- a/package-drone/pom.xml
+++ b/package-drone/pom.xml
@@ -101,6 +101,21 @@
 			<artifactId>gson</artifactId>
 			<version>2.3.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-job</artifactId>
+			<version>1.14.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-cps</artifactId>
+			<version>1.14.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-basic-steps</artifactId>
+			<version>1.14.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/package-drone/pom.xml
+++ b/package-drone/pom.xml
@@ -57,6 +57,10 @@
 		</developer>
 	</developers>
 
+	<properties>
+		<jenkins-test-harness.version>2.17</jenkins-test-harness.version>
+	</properties>
+	
 	<scm>
 		<url>https://github.com/ctron/package-drone-jenkins</url>
 		<connection>scm:git:git://github.com/ctron/package-drone-jenkins.git</connection>

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/AbstractUploader.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/AbstractUploader.java
@@ -44,12 +44,16 @@ public abstract class AbstractUploader implements Uploader
 
     protected void fillProperties ( final Map<String, String> properties )
     {
-        final String jenkinsUrl = Jenkins.getInstance ().getRootUrl ();
-        if ( jenkinsUrl != null )
-        {
-            final String url = jenkinsUrl + this.run.getUrl ();
-            properties.put ( "jenkins:buildUrl", url );
-        }
+    	final Jenkins instance = Jenkins.getInstance();
+    	if (instance != null)
+    	{
+	        final String jenkinsUrl = instance.getRootUrl ();
+	        if ( jenkinsUrl != null )
+	        {
+	            final String url = jenkinsUrl + this.run.getUrl ();
+	            properties.put ( "jenkins:buildUrl", url );
+	        }
+	   	}
 
         properties.put ( "jenkins:timestamp", DATE_FORMATTER.format ( this.run.getTime () ) );
         properties.put ( "jenkins:buildId", this.run.getId () );

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/AbstractUploader.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/AbstractUploader.java
@@ -28,13 +28,6 @@ public abstract class AbstractUploader implements Uploader
 {
     protected static final Charset UTF_8 = Charset.forName ( "UTF-8" );
 
-    private static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat ( "yyyy-MM-dd HH:mm:ss.SSS" );
-
-    static
-    {
-        DATE_FORMATTER.setTimeZone ( TimeZone.getTimeZone ( "UTC" ) );
-    }
-
     protected final Run<?, ?> run;
 
     public AbstractUploader ( final Run<?, ?> run )
@@ -54,6 +47,9 @@ public abstract class AbstractUploader implements Uploader
 	            properties.put ( "jenkins:buildUrl", url );
 	        }
 	   	}
+
+        final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat ( "yyyy-MM-dd HH:mm:ss.SSS" );
+        DATE_FORMATTER.setTimeZone ( TimeZone.getTimeZone ( "UTC" ) );
 
         properties.put ( "jenkins:timestamp", DATE_FORMATTER.format ( this.run.getTime () ) );
         properties.put ( "jenkins:buildId", this.run.getId () );

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/BuildData.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/BuildData.java
@@ -21,7 +21,7 @@ import hudson.model.Action;
 import hudson.model.ProminentProjectAction;
 
 @ExportedBean ( defaultVisibility = 999 )
-public class BuildData implements Action, Serializable, Cloneable, ProminentProjectAction
+public class BuildData implements Action, Serializable, ProminentProjectAction
 {
     private static final long serialVersionUID = 1L;
 

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV2.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV2.java
@@ -70,12 +70,16 @@ public class UploaderV2 extends AbstractUploader
 
             b.setPath ( b.getPath () + String.format ( "/api/v2/upload/channel/%s/%s", URIUtil.encodeWithinPath ( this.channelId ), file ) );
 
-            final String jenkinsUrl = Jenkins.getInstance ().getRootUrl ();
-            if ( jenkinsUrl != null )
+            final Jenkins instance = Jenkins.getInstance ();
+            if (instance != null ) 
             {
-                final String url = jenkinsUrl + this.run.getUrl ();
-                b.addParameter ( "jenkins:buildUrl", url );
-            }
+	            final String jenkinsUrl = instance.getRootUrl ();
+	            if ( jenkinsUrl != null )
+	            {
+	                final String url = jenkinsUrl + this.run.getUrl ();
+	                b.addParameter ( "jenkins:buildUrl", url );
+	            }
+			}
             b.addParameter ( "jenkins:buildId", this.run.getId () );
             b.addParameter ( "jenkins:buildNumber", String.valueOf ( this.run.getNumber () ) );
             b.addParameter ( "jenkins:jobName", this.run.getParent ().getFullName () );

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV3.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV3.java
@@ -84,7 +84,10 @@ public class UploaderV3 extends AbstractUploader
         catch ( final IOException e )
         {
             // delete in case of early abort
-            this.tempFile.delete ();
+            if ( ! this.tempFile.delete () )
+            {
+                listener.getLogger ().println ( "It should never be logged... but got the FindBug error fixed" );
+            }
             throw e;
         }
     }

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV3.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV3.java
@@ -342,7 +342,10 @@ public class UploaderV3 extends AbstractUploader
     public void close () throws IOException
     {
         closeTransfer ();
-        this.tempFile.delete ();
+        if ( ! this.tempFile.delete () )
+        {
+            listener.getLogger ().println ( "It should never be logged... but got the FindBug error fixed" );
+        }
     }
 
     private void closeTransfer () throws IOException

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/steps/DroneRecorderStep.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/steps/DroneRecorderStep.java
@@ -1,0 +1,137 @@
+package de.dentrassi.pm.jenkins.steps;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import hudson.Util;
+
+import javax.annotation.Nonnull;
+
+public class DroneRecorderStep extends AbstractStepImpl {
+
+	private String serverUrl;
+	private String channel;
+	private String deployKey;
+	private String artifacts;
+	private String excludes;
+	private Boolean defaultExcludes = true;
+	private Boolean stripPath = false;
+	private Boolean allowEmptyArchive = false;
+	private Boolean failsAsUpload = false;
+	private Boolean uploadV3 = true;
+
+	@DataBoundConstructor
+    public DroneRecorderStep() {}
+
+    @DataBoundSetter 
+    public void setServerUrl(String serverUrl) {
+        this.serverUrl = Util.fixEmptyAndTrim(serverUrl);
+    }
+
+    @DataBoundSetter 
+    public void setChannel(String channel) {
+        this.channel = Util.fixEmptyAndTrim(channel);
+    }
+
+    @DataBoundSetter 
+    public void setDeployKey(String deployKey) {
+        this.deployKey = Util.fixEmptyAndTrim(deployKey);
+    }
+
+    @DataBoundSetter 
+    public void setArtifacts(String artifacts) {
+        this.artifacts = artifacts;
+    }
+
+    @DataBoundSetter 
+    public void setExcludes(String excludes) {
+        this.excludes = excludes;
+    }
+    
+    @DataBoundSetter 
+    public void setDefaultExcludes(Boolean defaultExcludes) {
+        this.defaultExcludes = defaultExcludes;
+    }
+    
+    @DataBoundSetter 
+    public void setStripPath(Boolean stripPath) {
+        this.stripPath = stripPath;
+    }
+
+   @DataBoundSetter 
+    public void setAllowEmptyArchive(Boolean allowEmptyArchive) {
+        this.allowEmptyArchive = allowEmptyArchive;
+    }
+
+    @DataBoundSetter 
+    public void setFailsAsUpload(Boolean failsAsUpload) {
+        this.failsAsUpload = failsAsUpload;
+    }
+
+    @DataBoundSetter 
+    public void setUploadV3(Boolean uploadV3) {
+        this.uploadV3 = uploadV3;
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public String getDeployKey() {
+        return deployKey;
+    }
+
+    public String getArtifacts() {
+        return artifacts;
+    }
+
+	public String getExcludes() {
+        return excludes;
+    }
+
+	public Boolean getDefaultExcludes() {
+        return defaultExcludes;
+    }
+
+	public Boolean getStripPath() {
+        return stripPath;
+    }
+
+	public Boolean getAllowEmptyArchive() {
+        return allowEmptyArchive;
+    }
+
+	public Boolean getFailsAsUpload() {
+        return failsAsUpload;
+    }
+
+	public Boolean getUploadV3() {
+        return uploadV3;
+    }
+
+	@Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+		
+        public DescriptorImpl() 
+        { 
+        	super(DroneRecorderStepExecution.class); 
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "packageDrone";
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Archive a pakage to Package Drone site";
+        }
+    }
+}

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/steps/DroneRecorderStepExecution.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/steps/DroneRecorderStepExecution.java
@@ -1,0 +1,43 @@
+package de.dentrassi.pm.jenkins.steps;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import de.dentrassi.pm.jenkins.DroneRecorder;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import javax.inject.Inject;
+
+public class DroneRecorderStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+    private static final long serialVersionUID = 1L;
+    
+    @Inject
+    private transient DroneRecorderStep step;
+
+    @StepContextParameter
+    private transient TaskListener listener;
+
+    @StepContextParameter
+    private transient Launcher launcher;
+
+    @StepContextParameter
+    private transient Run<?,?> build;
+
+    @StepContextParameter
+    private transient FilePath ws;
+
+    @Override
+    protected Void run() throws Exception {
+        listener.getLogger().println("Running Package Drone step.");
+
+        DroneRecorder publisher = new DroneRecorder(step.getServerUrl(), step.getChannel(), step.getDeployKey(), step.getArtifacts());
+        publisher.setStripPath(step.getStripPath());
+        publisher.setUploadV3(step.getUploadV3());
+        publisher.perform(build, ws, launcher, listener);
+
+        return null;
+    }
+
+}

--- a/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/config.jelly
+++ b/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/config.jelly
@@ -1,0 +1,56 @@
+<?jelly escape-by-default='true'?>
+<j:jelly
+	xmlns:j="jelly:core"
+	xmlns:st="jelly:stapler"
+	xmlns:d="jelly:define"
+	xmlns:l="/lib/layout"
+	xmlns:t="/lib/hudson"
+	xmlns:f="/lib/form"
+	xmlns:c="/lib/credentials"
+	>
+
+  	<f:entry title="${%Server URL}" field="serverUrl" description="The main URL to the Package Drone instance">
+		<f:textbox />
+	</f:entry>
+  
+	<f:entry title="${%Deploy Key}" field="deployKey">
+		<f:textbox />
+	</f:entry>
+	
+	<f:entry title="${%Channel}" field="channel" description="This may either be the channel ID or name">
+		<f:textbox />
+	</f:entry>
+  
+  	<f:entry title="${%Files to archive}" field="artifacts">
+		<f:textbox />
+	</f:entry>
+
+	<f:advanced>
+
+	    <f:entry title="${%Excludes}" field="excludes">
+			<f:textbox />
+	    </f:entry>
+	  
+		<f:entry field="defaultExcludes" >
+			<f:checkbox title="${%defaultExcludes}" default="true"/>
+		</f:entry>
+		
+		<f:entry field="stripPath" >
+			<f:checkbox title="${%stripPath}" default="true"/>
+		</f:entry>
+
+		<f:entry field="allowEmptyArchive" >
+			<f:checkbox title="${%allowEmptyArchive}" default="false"/>
+		</f:entry>
+
+		<f:entry field="failsAsUpload" >
+			<f:checkbox title="${%failsAsUpload}" default="false"/>
+		</f:entry>
+		
+		<f:entry field="uploadV3" >
+            <f:checkbox title="${%uploadV3}" default="false"/>
+        </f:entry>
+	
+	</f:advanced>
+        
+</j:jelly>

--- a/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/config.properties
+++ b/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/config.properties
@@ -1,0 +1,7 @@
+defaultExcludes=Default excludes
+stripPath=Strip path
+# Do not fail build if archiving returns nothing
+allowEmptyArchive=Do not fail build if archiving returns nothing
+# Mark the build as failed if the upload fails
+failsAsUpload=Fail the build if upload fails
+uploadV3=Upload using V3 of the Upload API

--- a/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/help-serverUrl.html
+++ b/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/help-serverUrl.html
@@ -1,0 +1,3 @@
+<div>
+  The main URL of the server. Not to any channel or artifact but to the server only.
+</div>

--- a/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/help-stripPath.html
+++ b/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/help-stripPath.html
@@ -1,0 +1,4 @@
+<div>
+  This will strip the leading directories from the uploaded file name. For example the file
+  <code>foo/bar/file</code> will get uploaded as <code>file</code> instead.
+</div>

--- a/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/help-uploadV3.html
+++ b/package-drone/src/main/resources/de/dentrassi/pm/jenkins/steps/DroneRecorderStep/help-uploadV3.html
@@ -1,0 +1,5 @@
+<div>
+    This will upload all artifacts in a single transfer archive,
+    which is faster but requires the Upload API V3, which is only
+    present in Eclipse Package Drone&trade; since version 0.14.0.
+</div>


### PR DESCRIPTION
Updated POM and added Pipeline functionality.
The following pipeline file worked:

node ('master') 
{
    sh (
        script: 'wget -q http://obelix/repos/fcd-rhel7/APPdbmon/APPdbmon-1.2.2-999-rhel7-x86_64.rpm'
    )
    packageDrone (
        artifacts: '*.rpm', 
        channel: 'test', 
        deployKey: 'a983b48e4c685936bab12a9bcda897a5015d793e8a824c83b81c076fb6c11e70',
        serverUrl: 'http://repo:8080'
    )
}

PS: on a node it still gives a error because DefaultHttpClient and Run can't be serialized. This is a bit more work in the 0.3.x release.