### PR TITLE
The httpclient in never closed if executed on a Jenkins node

### DIFF
--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV2.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV2.java
@@ -27,6 +27,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
 
 import hudson.model.TaskListener;
 
@@ -44,10 +45,10 @@ public class UploaderV2 extends AbstractUploader
 
     private boolean failed;
 
-    public UploaderV2 ( final HttpClient client, final RunData runData, final TaskListener listener, final String serverUrl, final String deployKey, final String channelId )
+    public UploaderV2 ( final RunData runData, final TaskListener listener, final String serverUrl, final String deployKey, final String channelId )
     {
         super ( runData );
-        this.client = client;
+        this.client = new DefaultHttpClient ();
         this.listener = listener;
         this.serverUrl = serverUrl;
         this.deployKey = deployKey;
@@ -155,6 +156,10 @@ public class UploaderV2 extends AbstractUploader
     @Override
     public void close ()
     {
-        // nothing to do
+        if ( this.client != null )
+        {
+            this.client.getConnectionManager ().shutdown ();
+        }
     }
+
 }

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV3.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderV3.java
@@ -34,6 +34,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.eclipse.packagedrone.repo.api.transfer.TransferArchiveWriter;
 import org.eclipse.packagedrone.repo.api.upload.ArtifactInformation;
 import org.eclipse.packagedrone.repo.api.upload.RejectedArtifact;
@@ -63,10 +64,10 @@ public class UploaderV3 extends AbstractUploader
 
     private TransferArchiveWriter transfer;
 
-    public UploaderV3(final HttpClient client, final RunData runData, final TaskListener listener, final String serverUrl, final String deployKey, final String channelId) throws IOException
+    public UploaderV3(final RunData runData, final TaskListener listener, final String serverUrl, final String deployKey, final String channelId) throws IOException
     {
         super(runData);
-        this.client = client;
+        this.client = new DefaultHttpClient ();
         this.listener = listener;
         this.serverUrl = serverUrl;
         this.deployKey = deployKey;


### PR DESCRIPTION
I notice that the httpclient instantiated in the UploadFiles class is saved in a transient field (because is not serialisable) to be closed later in the build step.

The UploadFiles is a `MasterToSlaveFileCallable` and by design it could be executed on a slave node. The httpclient instantiated in the `UploadFiles.invoke()` method could not be closed because the httpclient instance is not serialised back to the master node.

To ensure the httpclient is closed correctly I moved the instantiation of the HTTP client inside the specific Uploader implementations, this has two advantages:
* Uploader can handle the whole HTTP client lifecycle during the execution in a Jenkins node and close when the task is completed;
* customise the client configuration for each Uploader implementation (for example in case new version use different authentication methods or use XML instead JSON etc etc)