### PR TITLE
Enable integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+
+before_script:
+- cd package-drone
+
+script:
+- mvn test coveralls:report -P enable-jacoco -B

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # package-drone-jenkins
 
+[![Build Status](https://travis-ci.org/ctron/package-drone-jenkins.svg?branch=master)](https://travis-ci.org/ctron/package-drone-jenkins) [![Coverage Status](https://coveralls.io/repos/github/ctron/package-drone-jenkins/badge.svg?branch=master)](https://coveralls.io/github/ctron/package-drone-jenkins?branch=master)
+
 A Package Drone Plugin for Jenkins
 
 [Eclipse Package Drone](https://eclipse.org/package-drone) is a

--- a/package-drone/pom.xml
+++ b/package-drone/pom.xml
@@ -109,4 +109,44 @@
 		<powermock.version>1.7.0RC4</powermock.version>
 	</properties>
 
+	<profiles>
+		<profile>
+			<id>enable-jacoco</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.eluder.coveralls</groupId>
+							<artifactId>coveralls-maven-plugin</artifactId>
+							<version>4.3.0</version>
+							<configuration>
+								<repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>0.7.9</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report</id>
+								<phase>test</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Could you enable also this project to be build with Travis CI, this simplify the way to handle PR in the future (when there are more unit test).

And I do not know if you have a preferred site where publish coverage. If not this PR enable you on https://coveralls.io to publish the coverage. In case you enable coveralls profile please provide a secret travis enviroment variable `COVERALLS_REPO_TOKEN` with the coveralls token