### PR TITLE
Make request using jenkins proxy settings

### DIFF
--- a/package-drone/pom.xml
+++ b/package-drone/pom.xml
@@ -72,7 +72,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
+			<artifactId>fluent-hc</artifactId>
 			<version>4.5.3</version>
 		</dependency>
 		<dependency>

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/http/DroneClient.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/http/DroneClient.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Nikolas Falco.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Nikolas Falco - author of some PRs
+ *******************************************************************************/
+package de.dentrassi.pm.jenkins.http;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.util.URIUtil;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.impl.client.HttpClients;
+
+/**
+ * An HTTP client to comunicate with the package drone server endpoints.
+ * <p>
+ * This class also take in account also the Jenkins proxy settings.
+ *
+ * @author nikolasfalco
+ */
+public class DroneClient implements Closeable
+{
+    private HttpClient client;
+
+    private String serverURL;
+
+    private String password;
+
+    private String user;
+
+    private String channel;
+
+    public void setServerURL ( @Nonnull String serverURL )
+    {
+        this.serverURL = serverURL;
+    }
+
+    public void setCredentials ( @Nonnull String user, @Nullable String password )
+    {
+        this.user = user;
+        this.password = password;
+    }
+
+    public void setChannel ( String channel )
+    {
+        this.channel = channel;
+    }
+
+    public HttpResponse uploadToChannelV2 ( Map<String, String> properties, String artifact, File file ) throws IOException
+    {
+        verify ();
+
+        final URI uri;
+        try
+        {
+            final URIBuilder builder = new URIBuilder ( serverURL );
+
+            builder.setUserInfo ( user, password );
+
+            builder.setPath ( String.format ( "%s/api/v2/upload/channel/%s/%s", builder.getPath (), URIUtil.encodeWithinPath ( channel ), URIUtil.encodeWithinPath ( artifact ) ) );
+
+            for ( final Map.Entry<String, String> entry : properties.entrySet () )
+            {
+                builder.addParameter ( URIUtil.encodeWithinQuery ( entry.getKey () ), URIUtil.encodeWithinQuery ( entry.getValue () ) );
+            }
+
+            uri = builder.build ();
+        }
+        catch ( URISyntaxException e )
+        {
+            throw new URIException ( e.getReason () );
+        }
+
+        final HttpPut httpPut = new HttpPut ( uri );
+        httpPut.setEntity ( new FileEntity ( file ) );
+
+        return client.execute ( httpPut );
+    }
+
+    private void verify ()
+    {
+        if ( serverURL == null )
+        {
+            throw new IllegalStateException ( "Miss the server URL" );
+        }
+        if ( user == null )
+        {
+            throw new IllegalStateException ( "Miss the user" );
+        }
+        if ( password == null )
+        {
+            throw new IllegalStateException ( "Miss the password" );
+        }
+
+        if ( client == null )
+        {
+            initialiseClient ();
+        }
+    }
+
+    public HttpResponse uploadToChannelV3 ( File file ) throws IOException
+    {
+        verify ();
+
+        final URI uri;
+        try
+        {
+            final URIBuilder builder = new URIBuilder ( serverURL );
+            builder.setPath ( String.format ( "%s/api/v3/upload/archive/channel/%s", builder.getPath (), URIUtil.encodeWithinPath ( channel ) ) );
+            uri = builder.build ();
+        }
+        catch ( URISyntaxException e )
+        {
+            throw new IOException ( "Upload URL syntax error: " + e.getReason (), e );
+        }
+
+        final HttpPut httpPut = new HttpPut ( uri );
+
+        final String encodedAuth = Base64.encodeBase64String ( ( String.format ( "%s:%s", user, password ).getBytes ( "ISO-8859-1" ) ) );
+        httpPut.setHeader ( HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth );
+
+        httpPut.setEntity ( new FileEntity ( file ) );
+
+        return client.execute ( httpPut );
+    }
+
+    protected void initialiseClient ()
+    {
+        client = HttpClients.createDefault ();
+        // proxy settings
+    }
+
+    @Override
+    public void close ()
+    {
+        HttpClientUtils.closeQuietly ( this.client );
+    }
+
+}

--- a/package-drone/src/test/java/de/dentrassi/pm/jenkins/AbstractUploaderTest.java
+++ b/package-drone/src/test/java/de/dentrassi/pm/jenkins/AbstractUploaderTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Nikolas Falco.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Nikolas Falco - author of some PRs
+ *******************************************************************************/
+package de.dentrassi.pm.jenkins;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.MockExecutor;
+import org.apache.http.client.fluent.Response;
+
+import de.dentrassi.pm.jenkins.http.DroneClient;
+import hudson.ProxyConfiguration;
+
+abstract class AbstractUploaderTest
+{
+
+    protected abstract HttpResponse buildResponse ( Object payload, int statusCode ) throws Exception;
+
+    protected Response mockResponse ( HttpResponse response ) throws Exception
+    {
+        Response mockResponse = mock ( Response.class );
+        when ( mockResponse.returnResponse () ).thenReturn ( response );
+
+        return mockResponse;
+    }
+
+    protected DroneClient mockDroneClient ( final Executor executor )
+    {
+        return new DroneClient () {
+            @Override
+            protected Executor createExecutor ()
+            {
+                return executor;
+            }
+
+            @Override
+            protected ProxyConfiguration getProxy ()
+            {
+                return null;
+            }
+        };
+    }
+
+    protected Executor mockExecutor ()
+    {
+        Executor executor = mock ( MockExecutor.class );
+        when ( executor.auth ( any ( AuthScope.class ), any ( Credentials.class ) ) ).thenReturn ( executor );
+        when ( executor.authPreemptive ( any ( HttpHost.class ) ) ).thenReturn ( executor );
+        when ( executor.authPreemptiveProxy ( any ( HttpHost.class ) ) ).thenReturn ( executor );
+        return executor;
+    }
+
+}

--- a/package-drone/src/test/java/de/dentrassi/pm/jenkins/DroneClientTest.java
+++ b/package-drone/src/test/java/de/dentrassi/pm/jenkins/DroneClientTest.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Nikolas Falco.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Nikolas Falco - author of some PRs
+ *******************************************************************************/
+package de.dentrassi.pm.jenkins;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Collections;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.MockExecutor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+
+import de.dentrassi.pm.jenkins.http.DroneClient;
+import hudson.ProxyConfiguration;
+
+public class DroneClientTest
+{
+    @Rule
+    public JenkinsRule r = new JenkinsRule ();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder ();
+
+    @Test ( expected = IllegalStateException.class )
+    public void missing_serverURL () throws Exception
+    {
+        try ( DroneClient client = new DroneClient () )
+        {
+            client.setChannel ( "channel" );
+            client.setCredentials ( "user", "password" );
+            client.uploadToChannelV3 ( new File ( "" ) );
+        }
+    }
+
+    @Test ( expected = IllegalStateException.class )
+    public void missing_credentials () throws Exception
+    {
+        try ( DroneClient client = new DroneClient () )
+        {
+            client.setServerURL ( "http://pdrone.org" );
+            client.setChannel ( "channel" );
+            client.uploadToChannelV3 ( new File ( "" ) );
+        }
+    }
+
+    @Test ( expected = IllegalStateException.class )
+    public void missing_channel () throws Exception
+    {
+        try ( DroneClient client = new DroneClient () )
+        {
+            client.setServerURL ( "http://pdrone.org" );
+            client.setCredentials ( "user", "password" );
+            client.uploadToChannelV3 ( new File ( "" ) );
+        }
+    }
+
+    @Test
+    public void test_no_proxy () throws Exception
+    {
+        final Executor executor = mockExecutor ();
+
+        DroneClient droneClient = new DroneClient () {
+            @Override
+            protected Executor createExecutor ()
+            {
+                return executor;
+            }
+
+            @Override
+            protected ProxyConfiguration getProxy ()
+            {
+                return null;
+            }
+        };
+
+        try ( DroneClient client = droneClient )
+        {
+
+            URI serverURL = new URI ( "http://www.pdrone.org" );
+            String user = "user";
+            String password = "secret";
+            File payload = folder.newFile ();
+
+            client.setServerURL ( serverURL.toString () );
+            client.setChannel ( "channel" );
+            client.setCredentials ( user, password );
+            client.uploadToChannelV3 ( payload );
+
+            HttpHost target = new HttpHost ( serverURL.getHost (), serverURL.getPort (), serverURL.getScheme () );
+            UsernamePasswordCredentials credentials = new UsernamePasswordCredentials ( user, password );
+
+            verify ( executor ).auth ( new AuthScope ( target ), credentials );
+            verify ( executor ).authPreemptive ( target );
+        }
+    }
+
+    @Test
+    public void verify_proxy_settings () throws Exception
+    {
+        Executor executor = mockExecutor ();
+        ProxyConfiguration proxy = new ProxyConfiguration ( "http://localhost", 8080, "anonymous", "password" );
+
+        DroneClient droneClient = mockClient ( executor, proxy );
+
+        try ( DroneClient client = droneClient )
+        {
+
+            URI serverURL = new URI ( "http://www.pdrone.org" );
+            String user = "user";
+            String password = "secret";
+            File payload = folder.newFile ();
+
+            client.setServerURL ( serverURL.toString () );
+            client.setChannel ( "channel" );
+            client.setCredentials ( user, password );
+            client.uploadToChannelV3 ( payload );
+
+            HttpHost targetHost = new HttpHost ( serverURL.getHost (), serverURL.getPort (), serverURL.getScheme () );
+            UsernamePasswordCredentials targetCredentials = new UsernamePasswordCredentials ( user, password );
+
+            HttpHost proxyHost = new HttpHost ( proxy.name, proxy.port );
+            UsernamePasswordCredentials proxyCredentials = new UsernamePasswordCredentials ( proxy.getUserName (), proxy.getPassword () );
+
+            verify ( executor ).auth ( new AuthScope ( targetHost ), targetCredentials );
+            verify ( executor ).auth ( new AuthScope ( proxyHost ), proxyCredentials );
+            verify ( executor ).authPreemptive ( targetHost );
+            verify ( executor ).authPreemptiveProxy ( proxyHost );
+
+            ArgumentCaptor<Request> argument = ArgumentCaptor.forClass ( Request.class );
+            verify ( executor ).execute ( argument.capture () );
+            Request request = argument.getValue ();
+
+            HttpHost setProxy = (HttpHost)ReflectionUtils.getValueIncludingSuperclasses ( "proxy", request );
+            Assert.assertThat ( setProxy, CoreMatchers.is ( proxyHost ) );
+        }
+    }
+
+    private DroneClient mockClient ( final Executor executor, final ProxyConfiguration proxy )
+    {
+        DroneClient droneClient = new DroneClient () {
+            @Override
+            protected Executor createExecutor ()
+            {
+                return executor;
+            }
+
+            @Override
+            protected ProxyConfiguration getProxy ()
+            {
+                return proxy;
+            }
+        };
+        return droneClient;
+    }
+
+    @Test
+    public void endpoint_V3 () throws Exception
+    {
+        Executor executor = mockExecutor ();
+
+        DroneClient droneClient = mockClient ( executor, null );
+
+        try ( DroneClient client = droneClient )
+        {
+
+            URI serverURL = new URI ( "http://www.pdrone.org" );
+            File artifact = folder.newFile ();
+            String payload = "test";
+            FileUtils.writeStringToFile ( artifact, payload );
+
+            client.setServerURL ( serverURL.toString () );
+            client.setChannel ( "channel" );
+            client.setCredentials ( "user", "secret" );
+            client.uploadToChannelV3 ( artifact );
+
+            ArgumentCaptor<Request> argument = ArgumentCaptor.forClass ( Request.class );
+            verify ( executor ).execute ( argument.capture () );
+            Request request = argument.getValue ();
+
+            HttpUriRequest put = (HttpUriRequest)ReflectionUtils.getValueIncludingSuperclasses ( "request", request );
+            Assert.assertThat ( put.getURI ().toString (), CoreMatchers.is ( "http://www.pdrone.org/api/v3/upload/archive/channel/channel" ) );
+
+            String entity = IOUtils.toString ( ( (HttpEntityEnclosingRequest)put ).getEntity ().getContent () );
+            Assert.assertThat ( entity, CoreMatchers.is ( payload ) );
+        }
+    }
+
+    @Test
+    public void endpoint_V2 () throws Exception
+    {
+        Executor executor = mockExecutor ();
+
+        DroneClient droneClient = mockClient ( executor, null );
+
+        try ( DroneClient client = droneClient )
+        {
+
+            File artifact = folder.newFile ();
+            String payload = "test";
+            FileUtils.writeStringToFile ( artifact, payload );
+
+            client.setServerURL ( "http://www.pdrone.org" );
+            client.setChannel ( "channel" );
+            client.setCredentials ( "user", "secret" );
+            String filename = artifact.getName ();
+            client.uploadToChannelV2 ( Collections.<String, String> emptyMap (), filename, artifact );
+
+            ArgumentCaptor<Request> argument = ArgumentCaptor.forClass ( Request.class );
+            verify ( executor ).execute ( argument.capture () );
+            Request request = argument.getValue ();
+
+            HttpUriRequest put = (HttpUriRequest)ReflectionUtils.getValueIncludingSuperclasses ( "request", request );
+            Assert.assertThat ( put.getURI ().toString (), CoreMatchers.is ( "http://www.pdrone.org/api/v2/upload/channel/channel/" + filename ) );
+
+            String entity = IOUtils.toString ( ( (HttpEntityEnclosingRequest)put ).getEntity ().getContent () );
+            Assert.assertThat ( entity, CoreMatchers.is ( payload ) );
+        }
+    }
+
+    private Executor mockExecutor () throws Exception
+    {
+        final Executor executor = mock ( MockExecutor.class );
+        when ( executor.auth ( any ( AuthScope.class ), any ( Credentials.class ) ) ).thenReturn ( executor );
+        when ( executor.authPreemptive ( any ( HttpHost.class ) ) ).thenReturn ( executor );
+        when ( executor.authPreemptiveProxy ( any ( HttpHost.class ) ) ).thenReturn ( executor );
+
+        Response mockResponse = mock ( Response.class );
+        when ( mockResponse.returnResponse () ).thenReturn ( null );
+        when ( executor.execute ( any ( Request.class ) ) ).thenReturn ( mockResponse );
+
+        return executor;
+    }
+}

--- a/package-drone/src/test/java/de/dentrassi/pm/jenkins/DroneRecorderValidatorTest.java
+++ b/package-drone/src/test/java/de/dentrassi/pm/jenkins/DroneRecorderValidatorTest.java
@@ -10,14 +10,16 @@
  *******************************************************************************/
 package de.dentrassi.pm.jenkins;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 

--- a/package-drone/src/test/java/org/apache/http/client/fluent/MockExecutor.java
+++ b/package-drone/src/test/java/org/apache/http/client/fluent/MockExecutor.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Nikolas Falco.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Nikolas Falco - author of some PRs
+ *******************************************************************************/
+package org.apache.http.client.fluent;
+
+public class MockExecutor extends Executor
+{
+
+    public MockExecutor ()
+    {
+        super ( null );
+    }
+
+}


### PR DESCRIPTION
Enables http requests to the package drone server using the jenkins proxy settings if defined.

As suggested in the issue #22 an HTTP client (DroneClient) is created to reduce duplicated code. In the meanwhile I had switch to http fluent APIs because the orginal HTTP client APIs are very bad to handle basic authentication and proxy authentication.