### PR TITLE
Move artifacts upload summary out of uploader implementation

### DIFF
--- a/package-drone/pom.xml
+++ b/package-drone/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.30</version>
+		<version>2.37</version>
 		<relativePath />
 	</parent>
 
@@ -86,6 +86,18 @@
 			<version>2.10.0</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<profiles>

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/AbstractUploader.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/AbstractUploader.java
@@ -15,14 +15,16 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 
+import de.dentrassi.pm.jenkins.UploaderResult.ArtifactResult;
 import de.dentrassi.pm.jenkins.http.DroneClient;
 
 public abstract class AbstractUploader implements Uploader
@@ -43,13 +45,13 @@ public abstract class AbstractUploader implements Uploader
      * Map containing the id and filename of the successfully uploaded artifacts
      * Fill from the upload results
      */
-    protected final Map<String, String> uploadedArtifacts;
+    protected final Set<ArtifactResult> uploadedArtifacts;
 
     public AbstractUploader ( final RunData runData, ServerData serverData )
     {
         this.runData = runData;
         this.filesToUpload = new LinkedHashMap<> ();
-        this.uploadedArtifacts = new HashMap<> ();
+        this.uploadedArtifacts = new LinkedHashSet<> ();
         this.sdf = new SimpleDateFormat ( "yyyy-MM-dd HH:mm:ss.SSS" );
         this.sdf.setTimeZone ( TimeZone.getTimeZone ( "UTC" ) );
         this.client = new DroneClient ();
@@ -104,9 +106,9 @@ public abstract class AbstractUploader implements Uploader
      * @see de.dentrassi.pm.jenkins.Uploader#getUploadedArtifacts()
      */
     @Override
-    public Map<String, String> getUploadedArtifacts ()
+    public Set<ArtifactResult> getUploadedArtifacts ()
     {
-        return Collections.unmodifiableMap ( uploadedArtifacts );
+        return Collections.unmodifiableSet ( uploadedArtifacts );
     }
 
     @Override

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/ConsoleUtils.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/ConsoleUtils.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBH SYSTEMS GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBH SYSTEMS GmbH - initial API and implementation
+ *     Nikolas Falco - author of some PRs
+ *******************************************************************************/
+package de.dentrassi.pm.jenkins;
+
+import java.text.MessageFormat;
+
+import de.dentrassi.pm.jenkins.UploaderResult.ArtifactResult;
+import hudson.console.ExpandableDetailsNote;
+
+/**
+ * Utility class to decorate log printed on a Jenkins console
+ */
+public final class ConsoleUtils
+{
+
+    private ConsoleUtils ()
+    {
+    }
+
+    /**
+     * Generates a summary of all artifacts uploaded to a pdrone server
+     * instance.
+     *
+     * @param serverData
+     *            destination server data.
+     * @param result
+     *            of the uploaded files.
+     * @return a expandable summary table.
+     */
+    public static ExpandableDetailsNote buildArtifactsList ( final ServerData serverData, final UploaderResult result )
+    {
+        final StringBuilder sb = new StringBuilder ();
+
+        sb.append ( "<table>" );
+        sb.append ( "<thead><tr><th>Name</th><th>Result</th><th>Size</th><th>Validation</th></tr></thead>" );
+
+        sb.append ( "<tbody>" );
+
+        int rejectedCount = 0;
+        for ( final ArtifactResult entry : result.getUploadedArtifacts () )
+        {
+            sb.append ( "<tr>" );
+
+            sb.append ( "<td>" ).append ( entry.getName () ).append ( "</td>" );
+            if ( !entry.isRejected () )
+            {
+                sb.append ( "<td>" ).append ( "<a target=\"_blank\" href=\"" ).append ( URLMaker.make ( serverData.getServerURL (), serverData.getChannel (), entry.getId () ) ).append ( "\">" ).append ( entry.getId () ).append ( "</a>" ).append ( "</td>" );
+                sb.append ( "<td>" ).append ( entry.getSize () ).append ( "</td>" );
+
+                sb.append ( "<td>" );
+                long errorsCount = entry.getErrors ();
+                long warningsCount = entry.getWarnings ();
+
+                if ( errorsCount > 0 )
+                {
+                    sb.append ( MessageFormat.format ( "{0,choice,1#1 error|1<{0,number,integer} errors}", errorsCount ) );
+                }
+                if ( warningsCount > 0 )
+                {
+                    if ( errorsCount > 0 )
+                    {
+                        sb.append ( ", " );
+                    }
+                    sb.append ( MessageFormat.format ( "{0,choice,1#1 error|1<{0,number,integer} warnings}", warningsCount ) );
+                }
+                sb.append ( "</td>" );
+            }
+            else
+            {
+                rejectedCount++;
+                sb.append ( "<td>" ).append ( entry.getReason () ).append ( "</td>" );
+            }
+
+            sb.append ( "</tr>" );
+        }
+        sb.append ( "</tbody></table>" );
+
+        return new ExpandableDetailsNote ( String.format ( "Uploaded: %s, rejected: %s", result.getUploadedArtifacts ().size (), rejectedCount ), sb.toString () );
+    }
+
+}

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/Uploader.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/Uploader.java
@@ -13,7 +13,9 @@ package de.dentrassi.pm.jenkins;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
+import java.util.Set;
+
+import de.dentrassi.pm.jenkins.UploaderResult.ArtifactResult;
 
 /**
  * The interface represent a task to perform the physical operations to upload
@@ -40,11 +42,11 @@ public interface Uploader extends Closeable
     public void performUpload () throws IOException;
 
     /**
-     * Returns all artifacts successfully uploaded to the server.
+     * Returns all artifacts uploaded to the server.
      *
-     * @return a map of identifier (assigned by the server) - artifact name
-     *         upload with success.
+     * @return a list of details of uploaded artifacts like identifier (assigned
+     *         by the server) - artifact name and so on.
      */
-    public Map<String, String> getUploadedArtifacts ();
+    public Set<ArtifactResult> getUploadedArtifacts ();
 
 }

--- a/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderResult.java
+++ b/package-drone/src/main/java/de/dentrassi/pm/jenkins/UploaderResult.java
@@ -12,8 +12,8 @@ package de.dentrassi.pm.jenkins;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Results of the Upload operation.
@@ -22,10 +22,170 @@ import java.util.Map;
  */
 public class UploaderResult implements Serializable
 {
+    public static class ArtifactResult implements Serializable
+    {
+        private static final long serialVersionUID = 3984585856661124436L;
+
+        private final String id;
+
+        private final String name;
+
+        private final long size;
+
+        private final String reason;
+
+        private final long errors;
+
+        private final long warnings;
+
+        private boolean isRejected;
+
+        private ArtifactResult ( final String id, final String name, final long size, final String rejectReason, final long errorsCount, final long warningsCount )
+        {
+            this.id = id;
+            this.name = name;
+            this.size = size;
+            this.reason = rejectReason;
+            this.isRejected = false;
+            this.errors = errorsCount;
+            this.warnings = warningsCount;
+        }
+
+        public ArtifactResult ( final String name, final String rejectReason, final long size )
+        {
+            this ( null, name, size, rejectReason, 0l, 0l );
+            this.isRejected = true;
+        }
+
+        public ArtifactResult ( final String id, final String name, final long size, final long errorsCount, final long warningsCount )
+        {
+            this ( id, name, size, null, errorsCount, warningsCount );
+        }
+
+        public String getId ()
+        {
+            return id;
+        }
+
+        public String getName ()
+        {
+            return name;
+        }
+
+        public long getSize ()
+        {
+            return size;
+        }
+
+        public String getReason ()
+        {
+            return reason;
+        }
+
+        public boolean isRejected ()
+        {
+            return isRejected;
+        }
+
+        public long getErrors ()
+        {
+            return errors;
+        }
+
+        public long getWarnings ()
+        {
+            return warnings;
+        }
+
+        @Override
+        public String toString ()
+        {
+            return name + "(" + id + ")";
+        }
+
+        @Override
+        public int hashCode () // generated
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + (int) ( errors ^ ( errors >>> 32 ) );
+            result = prime * result + ( ( id == null ) ? 0 : id.hashCode () );
+            result = prime * result + ( ( name == null ) ? 0 : name.hashCode () );
+            result = prime * result + ( ( reason == null ) ? 0 : reason.hashCode () );
+            result = prime * result + (int) ( size ^ ( size >>> 32 ) );
+            result = prime * result + (int) ( warnings ^ ( warnings >>> 32 ) );
+            return result;
+        }
+
+        @Override
+        public boolean equals ( Object obj ) // generated
+        {
+            if ( this == obj )
+            {
+                return true;
+            }
+            if ( obj == null )
+            {
+                return false;
+            }
+            if ( getClass () != obj.getClass () )
+            {
+                return false;
+            }
+            ArtifactResult other = (ArtifactResult)obj;
+            if ( errors != other.errors )
+            {
+                return false;
+            }
+            if ( id == null )
+            {
+                if ( other.id != null )
+                {
+                    return false;
+                }
+            }
+            else if ( !id.equals ( other.id ) )
+            {
+                return false;
+            }
+            if ( name == null )
+            {
+                if ( other.name != null )
+                {
+                    return false;
+                }
+            }
+            else if ( !name.equals ( other.name ) )
+            {
+                return false;
+            }
+            if ( reason == null )
+            {
+                if ( other.reason != null )
+                {
+                    return false;
+                }
+            }
+            else if ( !reason.equals ( other.reason ) )
+            {
+                return false;
+            }
+            if ( size != other.size )
+            {
+                return false;
+            }
+            if ( warnings != other.warnings )
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+
     private static final long serialVersionUID = -3089286880912224513L;
 
-    // Map containing the id and filename of the successfully uploaded artifacts
-    private Map<String, String> uploadedArtifacts = new HashMap<> ();
+    // collection of details of the uploaded artifacts
+    private Set<ArtifactResult> uploadedArtifacts = new LinkedHashSet<> ();
 
     private boolean isEmptyUpload = false;
 
@@ -38,9 +198,9 @@ public class UploaderResult implements Serializable
      * @return map containing identifier and filename of the successfully
      *         uploaded artifacts.
      */
-    public Map<String, String> getUploadedArtifacts ()
+    public Set<ArtifactResult> getUploadedArtifacts ()
     {
-        return Collections.unmodifiableMap ( uploadedArtifacts );
+        return Collections.unmodifiableSet ( uploadedArtifacts );
     }
 
     /**
@@ -49,9 +209,9 @@ public class UploaderResult implements Serializable
      * @param artifacts
      *            a map containing identifier and filename of artifacts.
      */
-    public void addUploadedArtifacts ( Map<String, String> artifacts )
+    public void addUploadedArtifacts ( Set<ArtifactResult> artifacts )
     {
-        this.uploadedArtifacts.putAll ( artifacts );
+        this.uploadedArtifacts.addAll ( artifacts );
     }
 
     /**

--- a/package-drone/src/test/java/de/dentrassi/pm/jenkins/DroneRecorderTest.java
+++ b/package-drone/src/test/java/de/dentrassi/pm/jenkins/DroneRecorderTest.java
@@ -21,9 +21,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Set;
 
 import org.hamcrest.CoreMatchers;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
@@ -38,6 +39,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 
+import de.dentrassi.pm.jenkins.UploaderResult.ArtifactResult;
 import de.dentrassi.pm.jenkins.util.LoggerListenerWrapper;
 import hudson.FilePath.FileCallable;
 import hudson.model.FreeStyleBuild;
@@ -144,8 +146,8 @@ public class DroneRecorderTest
     {
         UploaderResult result = new UploaderResult ();
         result.setFailed ( true );
-        HashMap<String, String> artifacts = new HashMap<>();
-        artifacts.put ( "18a1a4ba-f8fa-4a64-bcd2-14e996fb74ac", "file1.jar" );
+        Set<ArtifactResult> artifacts = new LinkedHashSet<> ();
+        artifacts.add ( new ArtifactResult ( "18a1a4ba-f8fa-4a64-bcd2-14e996fb74ac", "file1.jar", 100, 0, 0 ) );
         result.addUploadedArtifacts ( artifacts );
 
         String serverURL = "http://myserver.com/pdrone";
@@ -169,8 +171,8 @@ public class DroneRecorderTest
     {
         UploaderResult result = new UploaderResult ();
         result.setFailed ( true );
-        HashMap<String, String> artifacts = new HashMap<> ();
-        artifacts.put ( "18a1a4ba-f8fa-4a64-bcd2-14e996fb74ac", "file1.jar" );
+        Set<ArtifactResult> artifacts = new LinkedHashSet<> ();
+        artifacts.add ( new ArtifactResult ( "18a1a4ba-f8fa-4a64-bcd2-14e996fb74ac", "file1.jar", 100, 0, 0 ) );
         result.addUploadedArtifacts ( artifacts );
 
         String serverURL = "http://myserver.com/pdrone";
@@ -206,9 +208,9 @@ public class DroneRecorderTest
     public void test_upload_with_success () throws Exception
     {
         UploaderResult result = new UploaderResult ();
-        HashMap<String, String> artifacts = new HashMap<> ();
-        artifacts.put ( "18a1a4ba-f8fa-4a64-bcd2-14e996fb74ac", "file1.jar" );
-        artifacts.put ( "14e996fb74ac-4a64-bcd2-f8fa-18a1a4ba", "file2.jar" );
+        Set<ArtifactResult> artifacts = new LinkedHashSet<> ();
+        artifacts.add ( new ArtifactResult ( "18a1a4ba-f8fa-4a64-bcd2-14e996fb74ac", "file1.jar", 100, 0, 0 ) );
+        artifacts.add ( new ArtifactResult ( "14e996fb74ac-4a64-bcd2-f8fa-18a1a4ba", "file2.jar", 200, 0, 0 ) );
         result.addUploadedArtifacts ( artifacts );
 
         String serverURL = "http://myserver.com";
@@ -227,7 +229,7 @@ public class DroneRecorderTest
         verifyBuildData ( artifacts, serverURL, channel, build );
     }
 
-    private void verifyBuildData ( HashMap<String, String> artifacts, String serverURL, String channel, FreeStyleBuild build )
+    private void verifyBuildData ( Set<ArtifactResult> artifacts, String serverURL, String channel, FreeStyleBuild build )
     {
         BuildData buildData = build.getAction ( BuildData.class );
         Assert.assertThat ( buildData, CoreMatchers.notNullValue () );
@@ -239,11 +241,11 @@ public class DroneRecorderTest
 
         Map<String, String> artifactsInPage = buildData.getArtifacts ();
         Assert.assertThat ( artifactsInPage.size (), CoreMatchers.equalTo ( artifacts.size () ) );
-        for ( Entry<String, String> entry : artifacts.entrySet () )
+        for ( ArtifactResult artifact : artifacts )
         {
-            Assert.assertTrue ( artifactsInPage.containsKey ( entry.getValue () ) );
+            Assert.assertTrue ( artifactsInPage.containsKey ( artifact.getName () ) );
             // verify that value in build data is an URL
-            Assert.assertThat ( artifactsInPage.get ( entry.getValue () ), CoreMatchers.equalTo ( URLMaker.make ( serverURL, channel, entry.getKey () ) ) );
+            Assert.assertThat ( artifactsInPage.get ( artifact.getName () ), CoreMatchers.equalTo ( URLMaker.make ( serverURL, channel, artifact.getId () ) ) );
         }
     }
 

--- a/package-drone/src/test/java/de/dentrassi/pm/jenkins/UploadResultSerialisationTest.java
+++ b/package-drone/src/test/java/de/dentrassi/pm/jenkins/UploadResultSerialisationTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Nikolas Falco.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Nikolas Falco - author of some PRs
+ *******************************************************************************/
+package de.dentrassi.pm.jenkins;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import de.dentrassi.pm.jenkins.UploaderResult.ArtifactResult;
+
+public class UploadResultSerialisationTest
+{
+
+    @Rule
+    public TemporaryFolder fileRule = new TemporaryFolder ();
+
+    @Test
+    public void verify_that_the_return_type_of_callable_are_serialisable () throws Exception
+    {
+        ArtifactResult artifactResult = new ArtifactResult ( "name", "for nothing", 500 );
+        Set<ArtifactResult> artifacts = new HashSet<> ();
+        artifacts.add ( artifactResult );
+        UploaderResult result = new UploaderResult ();
+        result.addUploadedArtifacts ( artifacts );
+
+        File serFile = fileRule.newFile ();
+
+        // try to serialize
+        try ( OutputStream fileOut = new FileOutputStream ( serFile ) )
+        {
+            ObjectOutputStream out = new ObjectOutputStream ( fileOut );
+            out.writeObject ( result );
+            out.close ();
+        }
+
+        // try to deserialize
+        UploaderResult deserilised;
+        try ( InputStream fileIn = new FileInputStream ( serFile ) )
+        {
+            ObjectInputStream in = new ObjectInputStream ( fileIn );
+            deserilised = (UploaderResult)in.readObject ();
+            in.close ();
+        }
+
+        Assert.assertThat ( deserilised.isEmptyUpload (), CoreMatchers.equalTo ( result.isEmptyUpload () ) );
+        Assert.assertThat ( deserilised.isFailed (), CoreMatchers.equalTo ( result.isFailed () ) );
+        Assertions.assertThat ( deserilised.getUploadedArtifacts () ).containsAll ( result.getUploadedArtifacts () );
+    }
+}

--- a/package-drone/src/test/java/de/dentrassi/pm/jenkins/UploaderV2Test.java
+++ b/package-drone/src/test/java/de/dentrassi/pm/jenkins/UploaderV2Test.java
@@ -10,9 +10,15 @@
  *******************************************************************************/
 package de.dentrassi.pm.jenkins;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -21,7 +27,7 @@ import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
-import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import org.apache.http.HttpResponse;
@@ -33,12 +39,14 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
+import de.dentrassi.pm.jenkins.UploaderResult.ArtifactResult;
 import de.dentrassi.pm.jenkins.util.LoggerListenerWrapper;
 import hudson.util.ReflectionUtils;
 
@@ -127,9 +135,9 @@ public class UploaderV2Test extends AbstractUploaderTest
 
             uploader.performUpload ();
 
-            Map<String, String> uploadedArtifacts = uploader.getUploadedArtifacts ();
-            assertThat ( uploadedArtifacts.keySet (), CoreMatchers.hasItems ( "f1Id", "f2Id" ) );
-            assertThat ( uploadedArtifacts.values (), CoreMatchers.hasItems ( "f1", "f2" ) );
+            Set<ArtifactResult> uploadedArtifacts = uploader.getUploadedArtifacts ();
+            Assertions.assertThat ( uploadedArtifacts ).extracting ( "id" ).contains ( "f1Id", "f2Id" );
+            Assertions.assertThat ( uploadedArtifacts ).extracting ( "name" ).contains ( "f1", "f2" );
         }
     }
 
@@ -164,9 +172,9 @@ public class UploaderV2Test extends AbstractUploaderTest
                 assertThat ( e.getMessage (), CoreMatchers.is ( Messages.UploaderV2_failedToUpload ( "f2", 500, "Internal Server Error", "f2Id" ) ) );
             }
 
-            Map<String, String> uploadedArtifacts = uploader.getUploadedArtifacts ();
-            assertThat ( uploadedArtifacts.keySet (), CoreMatchers.hasItems ( "f1Id" ) );
-            assertThat ( uploadedArtifacts.values (), CoreMatchers.hasItems ( "f1" ) );
+            Set<ArtifactResult> uploadedArtifacts = uploader.getUploadedArtifacts ();
+            Assertions.assertThat ( uploadedArtifacts ).extracting ( "id" ).containsExactly ( "f1Id" );
+            Assertions.assertThat ( uploadedArtifacts ).extracting ( "name" ).containsExactly ( "f1" );
         }
     }
 

--- a/package-drone/src/test/java/de/dentrassi/pm/jenkins/UploaderV3Test.java
+++ b/package-drone/src/test/java/de/dentrassi/pm/jenkins/UploaderV3Test.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TimeZone;
 
 import org.apache.http.HttpResponse;
@@ -40,6 +41,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import org.assertj.core.api.Assertions;
 import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.packagedrone.repo.api.upload.ArtifactInformation;
 import org.eclipse.packagedrone.repo.api.upload.UploadError;
@@ -52,6 +54,7 @@ import org.mockito.ArgumentCaptor;
 
 import com.google.gson.Gson;
 
+import de.dentrassi.pm.jenkins.UploaderResult.ArtifactResult;
 import de.dentrassi.pm.jenkins.util.LoggerListenerWrapper;
 
 public class UploaderV3Test extends AbstractUploaderTest
@@ -114,7 +117,7 @@ public class UploaderV3Test extends AbstractUploaderTest
         artifacts.put ( "f1", "f1Id" );
         artifacts.put ( "f2", "f2Id" );
 
-        Map<String, String> uploadedArtifacts = null;
+        Set<ArtifactResult> uploadedArtifacts = null;
 
         // build uploader and mock its internal the http client
         try ( UploaderV3 uploader = spy ( new UploaderV3 ( runData, listener, serverData ) ) )
@@ -132,8 +135,8 @@ public class UploaderV3Test extends AbstractUploaderTest
             uploadedArtifacts = uploader.getUploadedArtifacts ();
         }
 
-        assertThat ( uploadedArtifacts.keySet (), CoreMatchers.hasItems ( artifacts.values ().toArray ( new String[0] ) ) );
-        assertThat ( uploadedArtifacts.values (), CoreMatchers.hasItems ( artifacts.keySet ().toArray ( new String[0] ) ) );
+        Assertions.assertThat ( uploadedArtifacts ).extracting ( "id" ).containsAll ( artifacts.values () );
+        Assertions.assertThat ( uploadedArtifacts ).extracting ( "name" ).containsAll ( artifacts.keySet () );
     }
 
     private UploadResult createHTTPResult ( UploaderV3 uploader, String channelId, Map<String, String> artifacts ) throws IOException
@@ -215,7 +218,7 @@ public class UploaderV3Test extends AbstractUploaderTest
                 assertThat ( e.getMessage (), CoreMatchers.containsString ( payload.getMessage () ) );
             }
 
-            Map<String, String> uploadedArtifacts = uploader.getUploadedArtifacts ();
+            Set<ArtifactResult> uploadedArtifacts = uploader.getUploadedArtifacts ();
             assertTrue ( "expected no uploaded artifacts with success", uploadedArtifacts.isEmpty () );
         }
     }


### PR DESCRIPTION
We had move the execution of our jobs from master to slave but happens unexpected exception in URLMaker when try to build URL.
The exception was hidden because, the only exception permitted on a FileCallable are IOException (or InterrupException). Looking the console the issue happens in makeArtifacts method of UploaderV3. In theory all server data in the callable should be available and should never happens any URLException anyway I had move the artifacts upload summary out of Uploader implementations since it's a logger decoration which has nothing to do with the uploaders logic.

So in short changes are:
- update to latest 2.x plugins pom
- move upload artifacts summary creation out of Uploader
- standardize the summary regardless of the version of the Uploader implementation